### PR TITLE
Makefile: fix ar flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ HDRS = ${CXX_HDRS}
 ############################################################################
 
 libboom.a: ${OBJECTS}
-	   ${AR} rc $@ $^
+	   ${AR} rcs $@ $^
 
 .PHONY: install
 install: libboom.a


### PR DESCRIPTION
On macOS the current code may produce a broken static library due to missing table of contents – because `ranlib` is not being run. As a substitute for that, `s` can be added to `ar` flags.