### PR TITLE
Fix generation of random seed on systems with 32-bit long (e.g. Windows).

### DIFF
--- a/distributions/rng.cpp
+++ b/distributions/rng.cpp
@@ -41,7 +41,7 @@ namespace BOOM {
     while (ans <= 2) {
       double u = runif_mt(rng) * static_cast<double>(
           std::numeric_limits<RNG::RngIntType>::max());
-      ans = lround(u);
+      ans = llround(u);
     }
     return ans;
   }


### PR DESCRIPTION
This fixes one issue in generation of random seed on Windows, where the long type is only 32-bit (but the code silently assumes at least 64-bit). On Windows, very often `u` would end up too large to fit into a long, and hence `lround` returns an unspecified value. 

With mingw-w64 v11 (Rtools45, Rtools44) and earlier, the value is `-2147483648` (`LONG_MIN`), which when cast to a 64-bit unsigned integer becomes something very large. The loop hence terminates and returns this value - but, it is a very common seed, much more common than other seeds, consequently, so the seed is not really random.

With mingw-w64 v12 (current version, not yet used in Rtools due to numerical issues) changed this unspecified behavior of `lround` by switching to UCRT. Zero is returned when the result does not fit into a long, which is very common. The loop then runs into further iterations. The symptoms are that package checks for R packages bsts and several other run into an infinite loop, they never finish. I've ended up debugging this as it appears as regression in mingw-w64 v12.

The patch simply switches to `llround`, which uses `long long`, which is guaranteed to be at least 64-bit. 

Now, I think there is one more issue in this code which this patch does not address. `u` will be in the range from 0 to `UINT64_MAX`, so a lot of these values will be too large to fit into a _signed_ 64-bit integer. These values will again end up being a fixed single unspecified value - which is then cast into an _unsigned_ 64-bit integer. So, if the goal is to have uniform distribution over the range of uint64_t, this function probably doesn't provide it. Maybe one could shift u to be in a suitable range for a signed 64-bit integer.

