### PR TITLE
Record the log likelihood of each MCMC draw in LogitBandit

### DIFF
--- a/Bandits/LogitBandit.cpp
+++ b/Bandits/LogitBandit.cpp
@@ -42,9 +42,11 @@ namespace BOOM {
 
   void LogitBandit::update_posterior(int ndraws) {
     coefficient_draws_.resize(ndraws, model_->xdim());
+    log_likelihood_draws_.resize(ndraws);
     for (int i = 0; i < ndraws; ++i) {
       model_->sample_posterior();
       coefficient_draws_.row(i) = model_->Beta();
+      log_likelihood_draws_[i] = model_->log_likelihood();
     }
   }
 
@@ -104,6 +106,7 @@ namespace BOOM {
       report_error(err.str());
     }
     coefficient_draws_ = draws;
+    log_likelihood_draws_.clear();
     model_->set_Beta(draws.last_row());
   }
   

--- a/Bandits/LogitBandit.hpp
+++ b/Bandits/LogitBandit.hpp
@@ -104,13 +104,23 @@ namespace BOOM {
       return coefficient_draws_;
     }
 
+    // The log likelihood of the training data evaluated at each MCMC draw,
+    // produced by the most recent call to update_posterior().  Element i
+    // corresponds to row i of draws().  Empty if the draws were supplied by
+    // set_draws(), because externally supplied draws have no recorded log
+    // likelihood.
+    const Vector &log_likelihood_draws() const {
+      return log_likelihood_draws_;
+    }
+
     void set_draws(const Matrix &draws);
-    
+
    private:
     Ptr<BinomialLogitModel> model_;
     Ptr<LinearBanditEncoder> encoder_;
 
     Matrix coefficient_draws_;
+    Vector log_likelihood_draws_;
   };
   
 }  // namespace BOOM

--- a/Interfaces/python/BayesBoom/Bandits/bandit_def.cpp
+++ b/Interfaces/python/BayesBoom/Bandits/bandit_def.cpp
@@ -327,6 +327,15 @@ namespace BayesBoom {
             [](const LogitBandit &bandit) {return bandit.draws();},
             "The matrix of MCMC draws of the model coefficients.  Row 'i' "
             "is the coefficient vector for MCMC draw i.")
+        .def_property_readonly(
+            "log_likelihood_draws",
+            [](const LogitBandit &bandit) {
+              return bandit.log_likelihood_draws();
+            },
+            "The log likelihood of the training data evaluated at each MCMC "
+            "draw from the most recent call to update_posterior().  Element "
+            "'i' corresponds to row i of coefficient_draws.  Empty if the "
+            "draws were supplied by set_coefficient_draws.")
         .def("set_coefficient_draws",
              [](LogitBandit &bandit, const Matrix &draws) {bandit.set_draws(draws);},
              py::arg("draws"),

--- a/Interfaces/python/bandits/BayesBoom/bandits/logit_bandit.py
+++ b/Interfaces/python/bandits/BayesBoom/bandits/logit_bandit.py
@@ -67,6 +67,20 @@ class LogitBandit:
         else:
             return R.to_numpy(self._boom_bandit.coefficient_draws)
 
+    @property
+    def log_likelihood_draws(self):
+        """
+        The log likelihood of the training data evaluated at each MCMC draw
+        from the most recent call to update_posterior.  Element i corresponds
+        to row i of coefficient_draws.  None before the first call to
+        update_posterior; empty if the draws were supplied by
+        set_coefficient_draws.
+        """
+        if not self._boom_bandit:
+            return None
+        else:
+            return R.to_numpy(self._boom_bandit.log_likelihood_draws)
+
     def set_coefficient_draws(self, draws):
         self.boom().set_coefficient_draws(R.to_boom_matrix(draws))
 

--- a/Interfaces/python/bandits/BayesBoom/bandits/test_logit_bandit.py
+++ b/Interfaces/python/bandits/BayesBoom/bandits/test_logit_bandit.py
@@ -68,6 +68,20 @@ class TestLogitBanditNoContext(unittest.TestCase):
         self.bandit.update_posterior(200)
         self.assertEqual(200, self.bandit.ndraws)
 
+    def test_log_likelihood_draws_before_update(self):
+        self.bandit.observe_data(0, 5, 10)
+        self.assertIsNone(self.bandit.log_likelihood_draws)
+
+    def test_log_likelihood_draws(self):
+        self.bandit.observe_data(0, 5, 10)
+        self.bandit.observe_data(1, 2, 10)
+        self.bandit.update_posterior(200)
+        loglike = self.bandit.log_likelihood_draws
+        self.assertEqual(200, len(loglike))
+        self.assertTrue(np.all(np.isfinite(loglike)))
+        # The sampler wanders, so the log likelihood varies across draws.
+        self.assertGreater(np.std(loglike), 0.0)
+
     def test_optimal_arm_probabilities_shape_and_sum(self):
         self.bandit.observe_data(0, 90, 100)
         self.bandit.observe_data(1, 30, 100)
@@ -154,6 +168,15 @@ class TestLogitBanditWithContext(unittest.TestCase):
         self.assertEqual(0, self.bandit.ndraws)
         self.bandit.update_posterior(200)
         self.assertEqual(200, self.bandit.ndraws)
+
+    def test_log_likelihood_draws_with_context(self):
+        ctx = self._ctx(1.5)
+        self.bandit.observe_data(0, 5, 10, ctx)
+        self.bandit.observe_data(1, 2, 10, ctx)
+        self.bandit.update_posterior(200)
+        loglike = self.bandit.log_likelihood_draws
+        self.assertEqual(200, len(loglike))
+        self.assertTrue(np.all(np.isfinite(loglike)))
 
     def test_optimal_arm_probs_with_context_sums_to_one(self):
         ctx = self._ctx(1.5)


### PR DESCRIPTION
`lm_spike` and `mlogit_spike` record the log likelihood at each MCMC iteration, which makes the standard likelihood trace health check easy. `LogitBandit` doesn't: its `update_posterior` loop runs in C++ and keeps only the coefficient draws.

This records `model_->log_likelihood()` after each `sample_posterior()` call and exposes the vector as `log_likelihood_draws` (C++ accessor, pybind property, python passthrough). Element i corresponds to row i of `coefficient_draws`. `set_draws` clears the vector, since externally supplied draws have no recorded likelihood. `LogitBanditExternalValue` inherits the binding.

Tests added to `test_logit_bandit.py` (length, finiteness, variation across draws, `None` before the first `update_posterior`); all 33 tests in the file pass against a locally built wheel. Also verified the recorded values against a hand computed binomial log likelihood at each draw: they match exactly, differing from the Bernoulli-only term by the expected constant sum of log binomial coefficients.
