### PR TITLE
Add AGENTS.md and STYLES.md for AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in BOOM. Read this before proposing any change. Code style lives in [STYLES.md](STYLES.md); read that too before writing or editing code.
+
+## How to behave in this repo
+
+- **Propose minimal diffs.** Show the changed lines in isolation and explain the fix *before* writing files. Never bury a small fix inside a large rewrite of the surrounding code.
+- **No drive-by changes.** Don't reformat, rename, or restructure code you weren't asked to touch. When editing a legacy file, match its local style even where it deviates from the conventions in STYLES.md.
+- **Explain before implementing.** For any non-trivial fix, state the bug, the cause, and the proposed change in a few sentences first, and wait for agreement.
+
+## Repo layout
+
+- C++ library at the root (`Models/`, `LinAlg/`, `Samplers/`, `distributions/`, `stats/`, `cpputil/`, `numopt/`, `TargetFun/`, `Bandits/`). Everything lives in `namespace BOOM`.
+- `Interfaces/python/` — the BayesBoom Python namespace package (pybind11 bindings plus pure-Python subpackages: `R`, `models`, `bandits`, `bsts`, `spikeslab`, ...).
+- `Interfaces/R/` — R packages (`Boom` core, then `BoomSpikeSlab`, `bsts`, ...).
+- `Eigen/` is vendored. Never modify it or add an external Eigen dependency.
+- `python_package/` and `rpackage/` are throwaway staging directories recreated by the install scripts. Never edit files there; edit the originals under `Interfaces/`.
+
+## Build and test
+
+- **C++ build:** `bazel build boom` (add `-c opt` for optimized). On macOS the hardcoded `-lpthread` in the top-level `BUILD` may need removing locally.
+- **C++ tests:** `./testall` (wraps `bazel test` over `Models/... cpputil/... LinAlg/... Samplers/... stats/... distributions/...`), or target a subtree directly: `bazel test //Models/Glm/...`.
+- **Python package:** built only via `./install/pyboom` from the repo root, which stages C++ sources into `python_package/` and builds the wheel. `pip install` on `Interfaces/python/BayesBoom` alone will fail. The compile is long (the entire C++ library builds into one `_boom` extension).
+- **Python tests:** stdlib `unittest` (`python -m unittest`), and they require the compiled `BayesBoom.boom` module to be installed first.
+- **R packages:** `./install/create_boom_rpackage -i` first (the others `LinkingTo: Boom`), then `./install/boom_spike_slab -i`, `./install/bsts -i`. macOS needs `gsed`.

--- a/STYLES.md
+++ b/STYLES.md
@@ -7,7 +7,7 @@ How code is written in BOOM. These conventions are described from the existing c
 ### Files
 
 - One class per `Foo.hpp`/`Foo.cpp` pair named after the class; free-function utilities are lowercase (`cpputil/report_error.hpp`). Tests are `snake_case_test.cc` in a `tests/` subdirectory next to the code.
-- Every file starts with the standard copyright block (Google line + Steven L. Scott LGPL block). Copy it verbatim from a neighboring file onto new files.
+- Most files start with the standard copyright block (Google line + Steven L. Scott LGPL block). Copy it verbatim from a neighboring file onto new files.
 - Include guards are `#ifndef BOOM_<NAME>_HPP_` style, never `#pragma once`. Close with `#endif  // BOOM_<NAME>_HPP_`.
 - In-repo headers are included with root-relative quoted paths (`#include "Models/Glm/Glm.hpp"`); a `.cpp` includes its own header first.
 
@@ -18,7 +18,7 @@ How code is written in BOOM. These conventions are described from the existing c
 
 ### Ownership and errors
 
-- Heap objects use the intrusive `Ptr<T>` smart pointer with `RefCounted`, allocated via the `NEW(Type, var)(args)` macro. Never `std::shared_ptr`. Cast through `.dcast<>()` / `.scast<>()`, not raw `dynamic_cast`.
+- Objects in the model hierarchy (`RefCounted` subclasses) use the intrusive `Ptr<T>` smart pointer, allocated via the `NEW(Type, var)(args)` macro; `std::shared_ptr` appears only for internal helpers that don't participate in reference counting. Cast through `.dcast<>()` / `.scast<>()`, not raw `dynamic_cast`.
 - Errors: build the message in a local `ostringstream err;` and call `report_error(err.str())`. Don't throw `std::runtime_error` directly.
 
 ### Documentation
@@ -50,7 +50,7 @@ googletest fixtures that seed the global RNG in the constructor (`GlobalRng::rng
 ### Object model
 
 - **Two-tier pattern.** Every model/bandit/encoder is a pure-Python class that is the source of truth for its own state, holding lazily-built `self._boom_*` handles. A `boom()` method constructs the C++ object on demand. `__setstate__` resets the `_boom_*` handles to `None`.
-- **Conversions go through the converters.** Use `R.to_boom_vector` / `R.to_boom_matrix` / `R.to_boom_spd` / `R.to_numpy` at the numpy/pandas ⇄ boom boundary; never construct `boom.Vector(...)` directly. Coerce scalars explicitly at the C++ boundary (`int(arm)`, `float(x)`).
+- **Conversions go through the converters.** In the newer subpackages (`bandits`, `models`), the numpy/pandas ⇄ boom boundary goes through `R.to_boom_vector` / `R.to_boom_matrix` / `R.to_boom_spd` / `R.to_numpy`; older subpackages construct `boom.Vector(...)` directly. Prefer the converters in new code. Coerce scalars explicitly at the C++ boundary (`int(arm)`, `float(x)`).
 - **Serialization:** user-facing classes implement `__getstate__`/`__setstate__` and a paired `<Thing>JsonEncoder` / `<Thing>JsonDecoder`, registered in the module-level registry where one exists. Tests round-trip both.
 
 ### Docstrings

--- a/STYLES.md
+++ b/STYLES.md
@@ -1,0 +1,91 @@
+# STYLES.md
+
+How code is written in BOOM. These conventions are described from the existing code; when editing a legacy file that deviates, match the surrounding file.
+
+## C++
+
+### Files
+
+- One class per `Foo.hpp`/`Foo.cpp` pair named after the class; free-function utilities are lowercase (`cpputil/report_error.hpp`). Tests are `snake_case_test.cc` in a `tests/` subdirectory next to the code.
+- Every file starts with the standard copyright block (Google line + Steven L. Scott LGPL block). Copy it verbatim from a neighboring file onto new files.
+- Include guards are `#ifndef BOOM_<NAME>_HPP_` style, never `#pragma once`. Close with `#endif  // BOOM_<NAME>_HPP_`.
+- In-repo headers are included with root-relative quoted paths (`#include "Models/Glm/Glm.hpp"`); a `.cpp` includes its own header first.
+
+### Naming
+
+- `PascalCase` classes, `lower_snake_case` methods and free functions, `ALL_CAPS` enumerators and macros.
+- Member variables end in a trailing underscore (`reference_count_`).
+
+### Ownership and errors
+
+- Heap objects use the intrusive `Ptr<T>` smart pointer with `RefCounted`, allocated via the `NEW(Type, var)(args)` macro. Never `std::shared_ptr`. Cast through `.dcast<>()` / `.scast<>()`, not raw `dynamic_cast`.
+- Errors: build the message in a local `ostringstream err;` and call `report_error(err.str())`. Don't throw `std::runtime_error` directly.
+
+### Documentation
+
+Plain `//` comments in the header, directly above the declaration, using indented `Args:` / `Returns:` / `Effects:` sections. Never Doxygen markup. Example:
+
+```cpp
+// Log likelihood function.
+// Args:
+//   beta: The vector of included coefficients (i.e. the dimension
+//     matches that of included_coefficients()).
+//
+// Returns:
+//   The value of log likelihood at the supplied beta.
+```
+
+`Effects:` documents side effects of mutating or void methods.
+
+### Formatting
+
+`.clang-format` at the repo root (Google style, 80 columns, 2-space indent, namespace bodies indented). Run clang-format on new code; don't reformat untouched code.
+
+### Tests
+
+googletest fixtures that seed the global RNG in the constructor (`GlobalRng::rng.seed(8675309);`), wired as `cc_test` (`size = "small"`) against `//:boom`, `//:boom_test_utils`, and `@googletest//:gtest_main`. Use `MatrixEquals` / `VectorEquals` from `test_utils` for array comparisons.
+
+## Python (BayesBoom)
+
+### Object model
+
+- **Two-tier pattern.** Every model/bandit/encoder is a pure-Python class that is the source of truth for its own state, holding lazily-built `self._boom_*` handles. A `boom()` method constructs the C++ object on demand. `__setstate__` resets the `_boom_*` handles to `None`.
+- **Conversions go through the converters.** Use `R.to_boom_vector` / `R.to_boom_matrix` / `R.to_boom_spd` / `R.to_numpy` at the numpy/pandas ⇄ boom boundary; never construct `boom.Vector(...)` directly. Coerce scalars explicitly at the C++ boundary (`int(arm)`, `float(x)`).
+- **Serialization:** user-facing classes implement `__getstate__`/`__setstate__` and a paired `<Thing>JsonEncoder` / `<Thing>JsonDecoder`, registered in the module-level registry where one exists. Tests round-trip both.
+
+### Docstrings
+
+Google-derived dialect with `Args:` / `Returns:` / `Effects:` / `Raises:` sections. `Effects:` documents side effects of mutating methods. Two-space hanging indent for argument descriptions; identifiers quoted with single quotes in prose. Every public function, method, and class gets one; `_`-private helpers may skip it. Class docstrings describe the concept; `__init__` carries the `Args:`. Example:
+
+```python
+def add_factor(self, factor_name: str, factor_levels, baseline_level: str = ""):
+    """
+    Add a factor to the experiment.
+
+    Args:
+      factor_name: The name of the experimental factor.  Think of this as
+        the variable name in a data frame.
+      factor_levels: The possible values the factor can assume.  A list of
+        strings.
+      baseline_level: The level of the factor to leave out when creating
+        dummy variables.
+
+    Effects:
+      The internal structure is updated to reflect the additional factor and
+      levels.
+    """
+```
+
+### Naming and types
+
+- `snake_case` functions and modules, `PascalCase` classes, `_`-prefixed private state, `UPPER_SNAKE` module constants.
+- Type hints are sparse and deliberate: annotate scalar parameters (`arm: int`); numpy/pandas parameters are documented in the docstring instead.
+- Imports are aliased canonically: `import BayesBoom.boom as boom`, `import BayesBoom.R as R`, `import BayesBoom.models as models`, `import numpy as np`, `import pandas as pd`.
+
+### Tests
+
+`unittest.TestCase` in `test_*.py`, `_make_*` factory helpers for fixtures, seeds set in `setUp` (`np.random.seed(8675309)`), and `np.testing.assert_array_almost_equal` for arrays.
+
+### Formatting
+
+80-column limit (flake8, the only configured lint rule), 4-space indent.


### PR DESCRIPTION
Adds two docs that AI coding agents (Claude Code, Codex, Cursor, etc.) pick up automatically when working in the repo:

- **AGENTS.md** — how agents should behave here (minimal diffs, explain the fix before writing files, no drive-by refactors), repo layout including the traps (vendored Eigen, the throwaway `python_package`/`rpackage` staging dirs), and the build/test commands for the C++, Python, and R surfaces.
- **STYLES.md** — the coding conventions as they exist in the code today: the `Args:`/`Returns:`/`Effects:` doc-comment dialect, `Ptr<T>`/`NEW()` ownership, `report_error()`, the two-tier Python/`boom()` pattern, the `R.to_boom_*` converter boundary, test conventions.

Everything here was extracted from the existing code rather than invented, but it's your repo and your rules — please edit freely or tell me what to change. The motivation: with these files in place, an agent proposes small reviewable diffs in your style instead of 1000 lines of boilerplate around a fix.

We're adopting the same docstring dialect on the Casia side so code crossing the BOOM/Casia boundary reads uniformly.