### PR TITLE
Fix LogitBandit.set_prior being silently ignored after boom()

### DIFF
--- a/Interfaces/python/bandits/BayesBoom/bandits/logit_bandit.py
+++ b/Interfaces/python/bandits/BayesBoom/bandits/logit_bandit.py
@@ -66,6 +66,10 @@ class LogitBandit:
         Set the prior distribution for the model to one of the standard
         priors for binomial logit models.  Accepted families of priors include
         MvnModel, BinomialLogitMvnPrior, and BinomialLogitSpikeSlabPrior.
+
+        Setting a prior discards any cached boom objects, including posterior
+        draws from a previous update_posterior call, so the next boom() call
+        rebuilds the sampler under the new prior.
         """
         if not isinstance(prior,
                           (models.MvnModel,
@@ -77,6 +81,12 @@ class LogitBandit:
             'LogitBandit.set_prior'.
             """)
         self._prior = prior
+        # Discard boom objects built under a previous prior (including the
+        # default prior installed when boom() is called before set_prior), so
+        # the next boom() call rebuilds the sampler with this one.
+        self._boom_model = None
+        self._boom_sampler = None
+        self._boom_bandit = None
 
     @property
     def coefficient_draws(self):

--- a/Interfaces/python/bandits/BayesBoom/bandits/test_logit_bandit.py
+++ b/Interfaces/python/bandits/BayesBoom/bandits/test_logit_bandit.py
@@ -665,5 +665,34 @@ class TestLinearBanditEncoderDim(unittest.TestCase):
         self.assertEqual(encoder.dim, len(row))
 
 
+class TestSetPriorAfterBoom(unittest.TestCase):
+
+    def test_set_prior_after_boom_rebuilds_sampler(self):
+        bandit = _make_bandit_with_context()
+        rng = np.random.default_rng(8675309)
+        n = 100
+        frame = pd.DataFrame({
+            "ButtonPosition": rng.choice(["Left", "Right"], n),
+            "ButtonColor": rng.choice(["Red", "Blue"], n),
+            "x1": rng.normal(size=n),
+        })
+        successes = pd.Series(rng.integers(0, 2, n))
+        trials = pd.Series(np.ones(n, dtype=int))
+        bandit.observe_past_data(
+            successes=successes, trials=trials, features=frame)
+
+        # Building a data-scaled prior requires the boom model, so boom() is
+        # touched before set_prior.
+        prior = models.LogitZellnerPrior.from_model(
+            bandit.boom().model, expected_model_size=1)
+        bandit.set_prior(prior)
+        bandit.update_posterior(200)
+
+        draws = np.asarray(bandit.coefficient_draws)
+        # The spike and slab sampler produces exact zeros.  The default
+        # Gaussian sampler installed by the first boom() call does not.
+        self.assertTrue(np.any(draws == 0))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A prior passed to `LogitBandit.set_prior` after the first `boom()` call is silently ignored: `boom()` caches the model, sampler, and bandit, and `_define_sampler` installs the default `MvnModel(0, I)` when no prior is set yet. Nothing invalidates that cache, so `update_posterior` samples under the default.

Building a data-scaled prior walks right into this, since `LogitZellnerPrior.from_model` needs the built boom model:

```python
bandit.observe_past_data(successes=s, trials=t, features=X)
prior = LogitZellnerPrior.from_model(bandit.boom().model, expected_model_size=1)  # builds + caches sampler
bandit.set_prior(prior)        # stored, never used
bandit.update_posterior(10000) # flat Gaussian, no variable selection
```

Fix: `set_prior` discards the cached boom objects so the next `boom()` call rebuilds the sampler under the new prior. Training data is kept on the wrapper, so the rebuild is lossless; draws from a previous prior are intentionally discarded (documented in the docstring).

Includes a regression test that reproduces the pattern above and asserts the draws contain exact zeros — it fails without the fix.
